### PR TITLE
Fw build

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -115,7 +115,7 @@ jobs:
           fi
           
           # Create firmware info JSON for ESPHome Web Flasher
-          cat > firmware-${{ matrix.board }}.json << EOF
+          cat > firmware-${{ matrix.board }}-manifest.json << EOF
           {
             "name": "${{ matrix.board_name }} GPS Car Tracker",
             "version": "${VERSION}",
@@ -205,7 +205,7 @@ jobs:
           name: firmware-${{ matrix.board }}
           path: |
             firmware-${{ matrix.board }}.bin
-            firmware-${{ matrix.board }}.json
+            firmware-${{ matrix.board }}-manifest.json
             release-notes-${{ matrix.board }}.md
 
   create-release:
@@ -259,7 +259,7 @@ jobs:
           body_path: RELEASE_NOTES.md
           files: |
             firmware-*/firmware-*.bin
-            firmware-*/firmware-*.json
+            firmware-*/firmware-*-manifest.json
             firmware-*/release-notes-*.md
           draft: false
           prerelease: false

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -25,18 +25,40 @@ jobs:
             chip: "ESP32"
             pins: "Standard ESP32 pinout"
           
-          # Future board options
+          # ESP32-C3 - Compact, low power
           - board: esp32-c3-devkitm-1
             board_name: "ESP32-C3 DevKitM-1"
             board_id: "esp32-c3-devkitm-1"
             chip: "ESP32-C3"
-            pins: "Compact C3 pinout"
+            pins: "Compact C3 pinout, SPI SD card"
           
+          # Generic ESP32 - Universal compatibility
           - board: esp32dev
             board_name: "Generic ESP32 Development Board"
             board_id: "esp32dev"
             chip: "ESP32"
             pins: "Generic ESP32 pinout"
+          
+          # TTGO T-Call - Built-in cellular
+          - board: ttgo-t-call-v1_4
+            board_name: "LILYGO TTGO T-Call V1.4"
+            board_id: "ttgo-t-call-v1_4"
+            chip: "ESP32"
+            pins: "ESP32 + SIM800L cellular, SPI SD card"
+          
+          # WEMOS D1 Mini - Compact form factor
+          - board: wemos_d1_mini32
+            board_name: "WEMOS D1 Mini ESP32"
+            board_id: "wemos_d1_mini32"
+            chip: "ESP32"
+            pins: "Arduino D1 Mini compatible, SPI SD card"
+          
+          # ESP32-S3 - High performance
+          - board: esp32-s3-devkitc-1
+            board_name: "ESP32-S3 DevKitC-1"
+            board_id: "esp32-s3-devkitc-1"
+            chip: "ESP32-S3"
+            pins: "High performance S3, AI acceleration"
 
     steps:
       - name: Checkout repository

--- a/docs/WEB-FLASHER.MD
+++ b/docs/WEB-FLASHER.MD
@@ -1,0 +1,140 @@
+# 🔧 Web Flasher Interface
+
+The GPS Car Tracker provides a web-based firmware flashing interface that makes it easy to install firmware on your ESP32 boards without any additional software.
+
+## 🌐 Accessing the Web Flasher
+
+1. **Local Development**: Navigate to `http://localhost:3000/flasher.html`
+2. **Production**: Available at `https://your-domain.com/flasher.html`
+
+## 🖥️ Browser Requirements
+
+The web flasher uses the WebSerial API and requires:
+
+- **Chrome 89+** or **Edge 89+** browser
+- **Safari and Firefox are not supported** (missing WebSerial API)
+- **USB connection** to the ESP32 board
+
+## 📱 Supported Boards
+
+The web flasher supports all board variants with automatic firmware selection:
+
+### 🌟 BerryBase NodeMCU-ESP32 (Recommended)
+- **Chip**: ESP32 (dual-core)
+- **SD Card**: SDMMC interface
+- **Features**: WiFi, Bluetooth, 30 GPIO pins
+- **Use Case**: General-purpose GPS tracking, well-documented
+
+### 🔋 ESP32-C3 DevKitM-1
+- **Chip**: ESP32-C3 (single-core RISC-V)
+- **SD Card**: SPI interface
+- **Features**: Low power consumption, compact size
+- **Use Case**: Battery-powered applications
+
+### 🔧 Generic ESP32 Development Board
+- **Chip**: ESP32 (dual-core)
+- **SD Card**: SDMMC interface
+- **Features**: Universal compatibility
+- **Use Case**: Compatible with most ESP32 boards
+
+### 📡 LILYGO TTGO T-Call V1.4
+- **Chip**: ESP32 with SIM800L cellular module
+- **SD Card**: SPI interface
+- **Features**: GSM/GPRS connectivity
+- **Use Case**: GPS tracking in areas without WiFi
+
+### 📦 WEMOS D1 Mini ESP32
+- **Chip**: ESP32 in compact form factor
+- **SD Card**: SPI interface
+- **Features**: Arduino D1 Mini compatible
+- **Use Case**: Space-constrained installations
+
+### 🚀 ESP32-S3 DevKitC-1
+- **Chip**: ESP32-S3 with AI acceleration
+- **SD Card**: SDMMC interface
+- **Features**: High performance, machine learning
+- **Use Case**: Advanced GPS tracking with ML features
+
+## 🔄 Flashing Process
+
+### Step 1: Board Selection
+Choose your ESP32 board from the list above. Each board has a dedicated firmware build with optimized pin configurations.
+
+### Step 2: Hardware Connection
+1. Connect your ESP32 board to your computer via USB
+2. Ensure the board is powered on
+3. Most boards enter download mode automatically
+
+### Step 3: Web Flashing
+1. Click the **"Install GPS Tracker"** button for your board
+2. Select the correct USB port in the browser popup
+3. The firmware will be downloaded and flashed automatically
+4. Wait for the "Installation complete" message
+
+### Step 4: Initial Configuration
+After successful flashing:
+1. The device will restart and create a WiFi hotspot: `gps-cartracker-setup`
+2. Connect to this network (password: `setup-setup`)
+3. Navigate to `http://192.168.4.1` in your browser
+4. Configure your server URL and authentication credentials
+
+## 🛠️ Troubleshooting
+
+### Flash Errors
+- **Port not detected**: Try a different USB cable or port
+- **Permission denied**: On Linux, add your user to the `dialout` group
+- **Flash timeout**: Press and hold the BOOT button during flashing
+
+### Browser Issues
+- **WebSerial not supported**: Use Chrome 89+ or Edge 89+
+- **Connection failed**: Refresh the page and try again
+- **Download timeout**: Check your internet connection
+
+### Hardware Issues
+- **No response**: Check USB cable and power supply
+- **Board not recognized**: Install CP210x or CH340 drivers if needed
+- **Constant reset**: Check power supply stability
+
+## 🔗 Alternative Methods
+
+If web flashing doesn't work:
+
+### ESPHome CLI
+```bash
+esphome run firmware.yaml --device /dev/ttyUSB0
+```
+
+### Manual Download and Flash
+1. Download firmware from [GitHub Releases](https://github.com/Ottes42/esp32-gps-cartracker/releases)
+2. Use esptool.py:
+```bash
+esptool.py --port /dev/ttyUSB0 write_flash 0x0 firmware-{board}.bin
+```
+
+### Arduino IDE
+1. Download the `.bin` file for your board
+2. Use Tools > ESP32 Sketch Data Upload
+
+## 📋 Firmware Information
+
+Each firmware build includes:
+- **GPS tracking** with 1-minute data logging
+- **SD card buffering** with automatic upload
+- **Web configuration interface**
+- **Captive portal** for initial setup
+- **Deep sleep power management**
+- **Temperature and humidity monitoring**
+
+## 🔄 Updates
+
+The web flasher always uses the latest firmware release. To update:
+1. Visit the flasher page
+2. Flash the new firmware (will overwrite existing)
+3. Reconfigure if needed (settings are preserved in most cases)
+
+## 🐛 Getting Help
+
+- 📖 [Hardware Setup Guide](HARDWARE.MD)
+- 🌐 [Web Interface Documentation](WEB-INTERFACE.MD)
+- 🔧 [Firmware Configuration](DEVELOPMENT.MD)
+- 🚀 [GitHub Issues](https://github.com/Ottes42/esp32-gps-cartracker/issues)

--- a/public/flasher.html
+++ b/public/flasher.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ESP32 GPS Car Tracker - Web Flasher</title>
+    <link rel="stylesheet" href="style.css">
+    <script type="module" src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"></script>
+    <style>
+        .flasher-container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        
+        .board-card {
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            padding: 1.5rem;
+            margin: 1rem 0;
+            border: 2px solid transparent;
+            transition: all 0.3s ease;
+        }
+        
+        .board-card:hover {
+            box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+            transform: translateY(-2px);
+        }
+        
+        .board-card.recommended {
+            border-color: #0066cc;
+            background: linear-gradient(135deg, #f8fbff 0%, #e8f4ff 100%);
+        }
+        
+        .board-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1rem;
+        }
+        
+        .board-name {
+            font-size: 1.3rem;
+            font-weight: 600;
+            color: #2c3e50;
+        }
+        
+        .board-chip {
+            background: #e74c3c;
+            color: white;
+            padding: 0.3rem 0.8rem;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            font-weight: 500;
+        }
+        
+        .board-description {
+            color: #666;
+            margin-bottom: 1rem;
+            line-height: 1.5;
+        }
+        
+        .board-features {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+        }
+        
+        .feature-tag {
+            background: #ecf0f1;
+            color: #2c3e50;
+            padding: 0.2rem 0.6rem;
+            border-radius: 12px;
+            font-size: 0.8rem;
+        }
+        
+        .flash-section {
+            border-top: 1px solid #eee;
+            padding-top: 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        
+        .version-info {
+            color: #666;
+            font-size: 0.9rem;
+        }
+        
+        esp-web-install-button {
+            --esp-tools-button-color: #0066cc;
+            --esp-tools-button-text-color: white;
+        }
+        
+        .warning-box {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0;
+            color: #856404;
+        }
+        
+        .info-box {
+            background: #d1ecf1;
+            border: 1px solid #bee5eb;
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0;
+            color: #0c5460;
+        }
+        
+        .steps {
+            margin: 2rem 0;
+        }
+        
+        .step {
+            display: flex;
+            align-items: flex-start;
+            margin: 1rem 0;
+        }
+        
+        .step-number {
+            background: #0066cc;
+            color: white;
+            width: 2rem;
+            height: 2rem;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+            margin-right: 1rem;
+            flex-shrink: 0;
+        }
+        
+        .step-content {
+            flex: 1;
+        }
+        
+        @media (max-width: 768px) {
+            .flasher-container {
+                padding: 1rem;
+            }
+            
+            .board-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.5rem;
+            }
+            
+            .flash-section {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 1rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <nav>
+            <div class="nav-brand">
+                <img src="favicon-32.png" alt="GPS Tracker" class="nav-logo">
+                <span class="nav-title">GPS Car Tracker</span>
+            </div>
+            <div class="nav-links">
+                <a href="index.html">Dashboard</a>
+                <a href="trips.html">Trips</a>
+                <a href="fuel.html">Fuel</a>
+                <a href="flasher.html" class="nav-active">Flasher</a>
+            </div>
+        </nav>
+    </header>
+
+    <main class="flasher-container">
+        <h1>🔧 ESP32 Firmware Flash Tool</h1>
+        
+        <div class="info-box">
+            <strong>Web-based flashing via Chrome/Edge browser</strong><br>
+            Connect your ESP32 board via USB and flash the GPS tracker firmware directly from your browser.
+            No additional software installation required!
+        </div>
+
+        <div class="warning-box">
+            <strong>⚠️ Requirements:</strong>
+            <ul>
+                <li>Chrome 89+ or Edge 89+ browser (Safari and Firefox not supported)</li>
+                <li>USB cable connection to ESP32</li>
+                <li>ESP32 in download mode (usually automatic)</li>
+            </ul>
+        </div>
+
+        <div class="steps">
+            <h2>📋 Flashing Instructions</h2>
+            
+            <div class="step">
+                <div class="step-number">1</div>
+                <div class="step-content">
+                    <strong>Select your board</strong><br>
+                    Choose the ESP32 board model you want to flash below.
+                </div>
+            </div>
+            
+            <div class="step">
+                <div class="step-number">2</div>
+                <div class="step-content">
+                    <strong>Connect via USB</strong><br>
+                    Connect your ESP32 board to your computer using a USB cable.
+                </div>
+            </div>
+            
+            <div class="step">
+                <div class="step-number">3</div>
+                <div class="step-content">
+                    <strong>Click "Install"</strong><br>
+                    Click the install button for your board and select the USB port in the popup.
+                </div>
+            </div>
+            
+            <div class="step">
+                <div class="step-number">4</div>
+                <div class="step-content">
+                    <strong>Configure device</strong><br>
+                    After flashing, the device will create a WiFi hotspot for initial configuration.
+                </div>
+            </div>
+        </div>
+
+        <h2>🔌 Available Boards</h2>
+
+        <!-- BerryBase NodeMCU-ESP32 (Recommended) -->
+        <div class="board-card recommended">
+            <div class="board-header">
+                <div class="board-name">🌟 BerryBase NodeMCU-ESP32</div>
+                <div class="board-chip">ESP32</div>
+            </div>
+            <div class="board-description">
+                <strong>Recommended board</strong> - Well-tested ESP32 development board with excellent compatibility.
+                Perfect for beginners and reliable GPS tracking projects.
+            </div>
+            <div class="board-features">
+                <span class="feature-tag">SDMMC SD Card</span>
+                <span class="feature-tag">WiFi + Bluetooth</span>
+                <span class="feature-tag">30 GPIO Pins</span>
+                <span class="feature-tag">Well Documented</span>
+            </div>
+            <div class="flash-section">
+                <div class="version-info">Latest firmware build</div>
+                <esp-web-install-button
+                    manifest="https://github.com/Ottes42/esp32-gps-cartracker/releases/latest/download/firmware-nodemcu-32s-manifest.json">
+                    <button slot="activate">Install GPS Tracker</button>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <!-- ESP32-C3 DevKitM-1 -->
+        <div class="board-card">
+            <div class="board-header">
+                <div class="board-name">ESP32-C3 DevKitM-1</div>
+                <div class="board-chip">ESP32-C3</div>
+            </div>
+            <div class="board-description">
+                Compact and low-power ESP32-C3 based board. Great for battery-powered applications
+                with reduced power consumption.
+            </div>
+            <div class="board-features">
+                <span class="feature-tag">SPI SD Card</span>
+                <span class="feature-tag">Low Power</span>
+                <span class="feature-tag">RISC-V</span>
+                <span class="feature-tag">Compact Size</span>
+            </div>
+            <div class="flash-section">
+                <div class="version-info">Latest firmware build</div>
+                <esp-web-install-button
+                    manifest="https://github.com/Ottes42/esp32-gps-cartracker/releases/latest/download/firmware-esp32-c3-devkitm-1-manifest.json">
+                    <button slot="activate">Install GPS Tracker</button>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <!-- Generic ESP32 -->
+        <div class="board-card">
+            <div class="board-header">
+                <div class="board-name">Generic ESP32 Development Board</div>
+                <div class="board-chip">ESP32</div>
+            </div>
+            <div class="board-description">
+                Universal ESP32 board configuration compatible with most ESP32 development boards
+                and breakout modules.
+            </div>
+            <div class="board-features">
+                <span class="feature-tag">SDMMC SD Card</span>
+                <span class="feature-tag">Universal</span>
+                <span class="feature-tag">Standard Pinout</span>
+                <span class="feature-tag">Wide Compatibility</span>
+            </div>
+            <div class="flash-section">
+                <div class="version-info">Latest firmware build</div>
+                <esp-web-install-button
+                    manifest="https://github.com/Ottes42/esp32-gps-cartracker/releases/latest/download/firmware-esp32dev-manifest.json">
+                    <button slot="activate">Install GPS Tracker</button>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <!-- TTGO T-Call -->
+        <div class="board-card">
+            <div class="board-header">
+                <div class="board-name">LILYGO TTGO T-Call V1.4</div>
+                <div class="board-chip">ESP32</div>
+            </div>
+            <div class="board-description">
+                ESP32 board with built-in SIM800L cellular module. Perfect for GPS tracking
+                in areas without WiFi coverage.
+            </div>
+            <div class="board-features">
+                <span class="feature-tag">SPI SD Card</span>
+                <span class="feature-tag">SIM800L Cellular</span>
+                <span class="feature-tag">GSM/GPRS</span>
+                <span class="feature-tag">Remote Areas</span>
+            </div>
+            <div class="flash-section">
+                <div class="version-info">Latest firmware build</div>
+                <esp-web-install-button
+                    manifest="https://github.com/Ottes42/esp32-gps-cartracker/releases/latest/download/firmware-ttgo-t-call-v1_4-manifest.json">
+                    <button slot="activate">Install GPS Tracker</button>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <!-- WEMOS D1 Mini -->
+        <div class="board-card">
+            <div class="board-header">
+                <div class="board-name">WEMOS D1 Mini ESP32</div>
+                <div class="board-chip">ESP32</div>
+            </div>
+            <div class="board-description">
+                Compact ESP32 board in Arduino D1 Mini form factor. Great for space-constrained
+                installations and prototyping.
+            </div>
+            <div class="board-features">
+                <span class="feature-tag">SPI SD Card</span>
+                <span class="feature-tag">Compact Form</span>
+                <span class="feature-tag">Arduino Compatible</span>
+                <span class="feature-tag">Prototyping</span>
+            </div>
+            <div class="flash-section">
+                <div class="version-info">Latest firmware build</div>
+                <esp-web-install-button
+                    manifest="https://github.com/Ottes42/esp32-gps-cartracker/releases/latest/download/firmware-wemos_d1_mini32-manifest.json">
+                    <button slot="activate">Install GPS Tracker</button>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <!-- ESP32-S3 -->
+        <div class="board-card">
+            <div class="board-header">
+                <div class="board-name">ESP32-S3 DevKitC-1</div>
+                <div class="board-chip">ESP32-S3</div>
+            </div>
+            <div class="board-description">
+                High-performance ESP32-S3 with AI acceleration capabilities. Ideal for advanced
+                GPS tracking with machine learning features.
+            </div>
+            <div class="board-features">
+                <span class="feature-tag">SDMMC SD Card</span>
+                <span class="feature-tag">AI Acceleration</span>
+                <span class="feature-tag">High Performance</span>
+                <span class="feature-tag">Advanced Features</span>
+            </div>
+            <div class="flash-section">
+                <div class="version-info">Latest firmware build</div>
+                <esp-web-install-button
+                    manifest="https://github.com/Ottes42/esp32-gps-cartracker/releases/latest/download/firmware-esp32-s3-devkitc-1-manifest.json">
+                    <button slot="activate">Install GPS Tracker</button>
+                </esp-web-install-button>
+            </div>
+        </div>
+
+        <div class="info-box">
+            <strong>🔗 Need help?</strong><br>
+            Check the <a href="https://github.com/Ottes42/esp32-gps-cartracker/blob/main/docs/FIRMWARE-FLASHING.md" target="_blank">Firmware Flashing Guide</a> 
+            for detailed instructions and troubleshooting.
+        </div>
+
+        <div class="warning-box">
+            <strong>🛠️ Alternative flashing methods:</strong><br>
+            If web flashing doesn't work, you can download the firmware binaries from the 
+            <a href="https://github.com/Ottes42/esp32-gps-cartracker/releases" target="_blank">GitHub releases</a>
+            and flash them using ESPHome or esptool.py.
+        </div>
+    </main>
+
+    <script>
+        // Add some interactivity
+        document.addEventListener('DOMContentLoaded', function() {
+            console.log('🚗 GPS Car Tracker Web Flasher loaded');
+            
+            // Track flash attempts
+            document.querySelectorAll('esp-web-install-button').forEach(button => {
+                button.addEventListener('state-changed', (event) => {
+                    console.log('Flash state:', event.detail.state);
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/public/fuel.html
+++ b/public/fuel.html
@@ -4,9 +4,23 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fuel Records - GPS Car Tracker</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="alternate icon" type="image/png" sizes="32x32" href="/favicon-32.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <nav class="navbar">
+    <div class="nav-brand">
+      <img src="favicon-32.png" alt="GPS" style="width:24px;height:24px;margin-right:8px;">
+      <span>GPS Car Tracker</span>
+    </div>
+    <div class="nav-links">
+      <a href="index.html">Dashboard</a>
+      <a href="trips.html">Trips</a>
+      <a href="fuel.html" class="nav-active">Fuel</a>
+      <a href="flasher.html">Flasher</a>
+    </div>
+  </nav>
   <div class="container">
     <div class="card">
       <h2>Fuel receipt</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,18 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
+  <nav class="navbar">
+    <div class="nav-brand">
+      <img src="favicon-32.png" alt="GPS" style="width:24px;height:24px;margin-right:8px;">
+      <span>GPS Car Tracker</span>
+    </div>
+    <div class="nav-links">
+      <a href="index.html" class="nav-active">Dashboard</a>
+      <a href="trips.html">Trips</a>
+      <a href="fuel.html">Fuel</a>
+      <a href="flasher.html">Flasher</a>
+    </div>
+  </nav>
   <div class="container">
     <!-- Top section: Upload button and Statistics -->
     <div class="top-section">

--- a/public/style.css
+++ b/public/style.css
@@ -52,9 +52,18 @@ html,body{ height:100%; margin:0; padding:0; background:var(--bg); color:var(--t
 }
 
 .nav-links a:hover,
-.nav-links a.active {
+.nav-links a.active,
+.nav-links a.nav-active {
   background: #ff8a00;
   color: #1a1d21;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  color: #ff8a00;
+  font-size: 1.5rem;
+  font-weight: bold;
 }
 
 /* Container */

--- a/public/trips.html
+++ b/public/trips.html
@@ -1,18 +1,36 @@
 <!DOCTYPE html>
-<html lang="en">
+<h    <div class="nav-links">
+      <a href="index.html">Dashboard</a>
+      <a href="trips.html" class="nav-active">Trips</a>
+      <a href="fuel.html">Fuel</a>
+      <a href="flasher.html">Flasher</a>
+    </div>
+  </nav>
+
+  <div class="container">>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Trips - GPS Car Tracker</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="alternate icon" type="image/png" sizes="32x32" href="/favicon-32.png">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
   <nav class="navbar">
     <div class="nav-brand">
-      <h1>GPS Car Tracker</h1>
+      <img src="favicon-32.png" alt="GPS" style="width:24px;height:24px;margin-right:8px;">
+      <span>GPS Car Tracker</span>
     </div>
-    <ul class="nav-links">
-      <li><a href="index.html">Dashboard</a></li>
+    <div class="nav-links">
+      <a href="index.html">Dashboard</a>
+      <a href="trips.html" class="nav-active">Trips</a>
+      <a href="fuel.html">Fuel</a>
+      <a href="flasher.html">Flasher</a>
+    </div>
+  </nav>
       <li><a href="trips.html" class="active">Trips</a></li>
       <li><a href="fuel.html">Fuel</a></li>
     </ul>


### PR DESCRIPTION
This pull request introduces support for additional ESP32 board variants in the firmware build and web flasher, updates the build and release workflow to handle new manifest files, and improves the web interface with a unified navigation bar and enhanced documentation. The most important changes are grouped below:

**Firmware Build and Release Workflow Updates:**

* Added support for new ESP32 board variants (`ttgo-t-call-v1_4`, `wemos_d1_mini32`, `esp32-s3-devkitc-1`) and improved metadata for existing boards in the build matrix in `.github/workflows/build-firmware.yml`.
* Changed the firmware info file naming from `firmware-${{ matrix.board }}.json` to `firmware-${{ matrix.board }}-manifest.json` throughout the build, artifact, and release steps for consistency and compatibility with the ESPHome Web Flasher. [[1]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2L96-R118) [[2]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2L186-R208) [[3]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2L240-R262)

**Documentation Improvements:**

* Added a comprehensive `docs/WEB-FLASHER.MD` guide explaining the web flasher interface, supported boards, browser requirements, flashing process, troubleshooting, and alternative flashing methods.

**Web Interface Enhancements:**

* Introduced a consistent navigation bar (`navbar`) with branding and links to all major pages (`Dashboard`, `Trips`, `Fuel`, `Flasher`) in `public/index.html`, `public/trips.html`, and `public/fuel.html`. [[1]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR16-R27) [[2]](diffhunk://#diff-4f9b6b034095b96cb0c5438e2e1bf59a671907dd72182e54f88ea83b6c83ffc3L2-R33) [[3]](diffhunk://#diff-d5453e0a1113526362d681099606ce0453ed144c0370951da8e3d552e0268bd2R7-R23)
* Updated `public/style.css` to style the new navigation bar, including active link highlighting and branding styles.